### PR TITLE
Fix: デプロイスクリプトを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "vitest",
-    "deploy": "npm run build && gh-pages -d dist"
+    "deploy": "npm run build && echo \"Build completed, starting gh-pages...\" && gh-pages -d react-ts-app/dist"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",


### PR DESCRIPTION
ビルド成果物の出力先ディレクトリに合わせて、`package.json` の `deploy` スクリプトを更新しました。

変更点:
- `scripts.deploy` の `gh-pages` コマンドの対象ディレクトリを `dist` から `react-ts-app/dist` に変更しました。

これにより、`npm run deploy` を実行した際に、正しいビルド成果物が GitHub Pages にデプロイされるようになります。 サンドボックス環境では、ビルドの成功と `gh-pages` コマンドが正しい引数で呼び出されることを確認しましたが、認証の制約により実際のデプロイはスキップされました。