### PR TITLE
Fix: Vite の base パスを設定

### DIFF
--- a/react-ts-app/vite.config.ts
+++ b/react-ts-app/vite.config.ts
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/FlowPrint/',
 })


### PR DESCRIPTION
GitHub Pages で正しく表示されるように、Vite の設定ファイル (`react-ts-app/vite.config.ts`) に `base: '/FlowPrint/'` を追加しました。

これにより、ビルド時に生成される HTML 内のアセット (CSS, JS) のパスが、リポジトリのサブディレクトリ構造 (`/FlowPrint/`) を考慮したものになり、GitHub Pages での表示崩れやリソースの読み込みエラーを防ぎます。