### PR TITLE
Fix: TaskModalのTransition.Childエラーを修正

### DIFF
--- a/react-ts-app/src/components/TaskModal.tsx
+++ b/react-ts-app/src/components/TaskModal.tsx
@@ -164,21 +164,21 @@ const TaskModal: React.FC<TaskModalProps> = ({ isOpen, onClose, taskToEdit, pare
     <Transition appear show={isOpen} as={Fragment}>
       <Dialog as="div" className="relative z-30" onClose={onClose}> {/* Increased z-index */}
         <Transition.Child
-          as={Fragment}
+          as="div" // Changed from Fragment to "div"
+          className="fixed inset-0 bg-black bg-opacity-40" // Moved className here
           enter="ease-out duration-300"
           enterFrom="opacity-0"
           enterTo="opacity-100"
           leave="ease-in duration-200"
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
-        >
-          <div className="fixed inset-0 bg-black bg-opacity-40" /> {/* Darker overlay */}
-        </Transition.Child>
+        /> {/* Self-closing */}
 
         <div className="fixed inset-0 overflow-y-auto">
           <div className="flex min-h-full items-center justify-center p-4 text-center">
             <Transition.Child
-              as={Fragment}
+              as={Dialog.Panel} // Changed from Fragment to Dialog.Panel
+              className="w-full max-w-lg transform overflow-hidden rounded-xl bg-white p-6 text-left align-middle shadow-2xl transition-all" // Moved Dialog.Panel props here
               enter="ease-out duration-300"
               enterFrom="opacity-0 scale-95"
               enterTo="opacity-100 scale-100"
@@ -186,10 +186,10 @@ const TaskModal: React.FC<TaskModalProps> = ({ isOpen, onClose, taskToEdit, pare
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-lg transform overflow-hidden rounded-xl bg-white p-6 text-left align-middle shadow-2xl transition-all"> {/* Increased max-width, shadow, rounded */}
-                <Dialog.Title as="h3" className="text-xl font-semibold leading-7 text-gray-900 mb-4"> {/* Increased font size, margin */}
-                  {taskToEdit ? 'タスク編集' : '新規タスク作成'}
-                </Dialog.Title>
+              {/* Dialog.Panel's children are now Transition.Child's children */}
+              <Dialog.Title as="h3" className="text-xl font-semibold leading-7 text-gray-900 mb-4"> {/* Increased font size, margin */}
+                {taskToEdit ? 'タスク編集' : '新規タスク作成'}
+              </Dialog.Title>
                 <form onSubmit={handleSubmit}>
                   <div className="space-y-4"> {/* Added space-y for better spacing */}
                     <div>


### PR DESCRIPTION
Headless UIのTransition.ChildコンポーネントがFragmentを直接の子としてレンダリングしようとしていたため発生していたエラーを修正しました。

TaskModal.tsx内の該当する2つのTransition.Childについて、as propをFragmentから適切な要素(divおよびDialog.Panel)に変更し、関連するpropsを調整しました。

これにより、新規タスク追加モーダル表示時のコンソールエラーが解消され、モーダルが正しく機能することが期待されます。