### PR TITLE
Fix: TaskModalのビルドエラーを修正

### DIFF
--- a/react-ts-app/src/components/TaskModal.tsx
+++ b/react-ts-app/src/components/TaskModal.tsx
@@ -275,7 +275,6 @@ const TaskModal: React.FC<TaskModalProps> = ({ isOpen, onClose, taskToEdit, pare
                     </button>
                   </div>
                 </form>
-              </Dialog.Panel>
             </Transition.Child>
           </div>
         </div>


### PR DESCRIPTION
前回のTransition.Childの修正で、不要なDialog.Panelの閉じタグが残っていたため発生していたビルドエラーを修正しました。

Transition.Child as={Dialog.Panel} の構造を正しくし、対応する閉じタグが適切になるようにしました。