### PR TITLE
Feat: タスク追加後に画面を自動更新

### DIFF
--- a/react-ts-app/src/components/Board.tsx
+++ b/react-ts-app/src/components/Board.tsx
@@ -32,6 +32,27 @@ const Board: React.FC = () => {
   const [selectedTaskHierarchy, setSelectedTaskHierarchy] = useState<string[]>([]);
   const [focusedColumnIdForPrint, setFocusedColumnIdForPrint] = useState<string | null>(null);
 
+  const handleTaskAdded = (newTaskId: string, taskParentId: string | null) => {
+    const newTask = tasks[newTaskId];
+    if (!newTask) return;
+
+    let newHierarchy: string[] = [];
+    if (taskParentId) {
+      const buildHierarchy = (currentId: string, path: string[]): string[] => {
+        const t = tasks[currentId];
+        if (!t) return path;
+        path.unshift(currentId);
+        return t.parentId ? buildHierarchy(t.parentId, path) : path;
+      };
+      newHierarchy = buildHierarchy(taskParentId, []);
+    }
+
+    setSelectedTaskId(newTaskId);
+
+    setActiveColumns(newHierarchy);
+
+  };
+
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);
   const [taskToEditInModal, setTaskToEditInModal] = useState<Task | null>(null);
   const [modalParentId, setModalParentId] = useState<string | null>(null);
@@ -231,6 +252,7 @@ const Board: React.FC = () => {
           onClose={() => setIsTaskModalOpen(false)}
           taskToEdit={taskToEditInModal}
           parentId={modalParentId}
+          onTaskAdded={handleTaskAdded}
         />
       )}
     </div>

--- a/react-ts-app/src/components/TaskModal.tsx
+++ b/react-ts-app/src/components/TaskModal.tsx
@@ -10,9 +10,10 @@ interface TaskModalProps {
   onClose: () => void;
   taskToEdit?: Task | null;
   parentId?: string | null;
+  onTaskAdded?: (newTaskId: string, parentId: string | null) => void;
 }
 
-const TaskModal: React.FC<TaskModalProps> = ({ isOpen, onClose, taskToEdit, parentId }) => {
+const TaskModal: React.FC<TaskModalProps> = ({ isOpen, onClose, taskToEdit, parentId, onTaskAdded }) => {
   const addTask = useTaskStore((state) => state.addTask);
   const updateTask = useTaskStore((state) => state.updateTask);
   const taskTemplates = useTaskStore(state => state.taskTemplates);
@@ -90,6 +91,7 @@ const TaskModal: React.FC<TaskModalProps> = ({ isOpen, onClose, taskToEdit, pare
     }
     if (createdTaskIds.length > 0) {
         setSelectedTaskId(createdTaskIds[0]); // Select the first created task
+        onTaskAdded?.(createdTaskIds[0], parentId !== undefined ? parentId : null);
     }
     onClose();
   }
@@ -102,6 +104,7 @@ const TaskModal: React.FC<TaskModalProps> = ({ isOpen, onClose, taskToEdit, pare
     const newIds = applyTemplate(selectedTemplate, parentId !== undefined ? parentId : null, new Date());
     if (newIds.length > 0) {
         setSelectedTaskId(newIds[0]); // Select the first top-level task from the template
+        onTaskAdded?.(newIds[0], parentId !== undefined ? parentId : null);
         // Optionally, open the first task for editing, or navigate to its column
         // setEditingTaskId(newIds[0]);
     }
@@ -150,6 +153,7 @@ const TaskModal: React.FC<TaskModalProps> = ({ isOpen, onClose, taskToEdit, pare
         };
         addTask(newTask);
         setSelectedTaskId(newTask.id); // Select the newly created task
+        onTaskAdded?.(newTask.id, newTask.parentId);
         // setEditingTaskId(newTask.id); // Optionally open for editing
       }
     }


### PR DESCRIPTION
TaskModalでタスクが追加された後、Boardコンポーネントに通知し、
アクティブなカラムと選択タスクを更新することで、
画面リロードなしに新しいタスクが表示されるようにしました。

変更点:
- TaskModalPropsにonTaskAddedコールバックを追加。
- TaskModalのタスク追加処理後(単一、分割、テンプレート)にonTaskAddedを呼び出し。
- BoardにhandleTaskAdded関数を追加し、新しいタスクの情報を元に setSelectedTaskIdとsetActiveColumnsを実行。
- TaskModalにonTaskAddedとしてhandleTaskAddedを渡すようにした。