### PR TITLE
Fix: タスク追加時の自動表示更新の改善

### DIFF
--- a/react-ts-app/src/components/Board.tsx
+++ b/react-ts-app/src/components/Board.tsx
@@ -33,13 +33,14 @@ const Board: React.FC = () => {
   const [focusedColumnIdForPrint, setFocusedColumnIdForPrint] = useState<string | null>(null);
 
   const handleTaskAdded = (newTaskId: string, taskParentId: string | null) => {
-    const newTask = tasks[newTaskId];
+    const currentTasks = useTaskStore.getState().tasks;
+    const newTask = currentTasks[newTaskId];
     if (!newTask) return;
 
-    let newHierarchy: string[] = [];
+    let newHierarchy: string[] = []; // 親までの階層
     if (taskParentId) {
       const buildHierarchy = (currentId: string, path: string[]): string[] => {
-        const t = tasks[currentId];
+        const t = currentTasks[currentId]; // currentTasks を使用
         if (!t) return path;
         path.unshift(currentId);
         return t.parentId ? buildHierarchy(t.parentId, path) : path;
@@ -47,10 +48,12 @@ const Board: React.FC = () => {
       newHierarchy = buildHierarchy(taskParentId, []);
     }
 
+    // 新しいタスク自身を含む完全な階層を作成
+    const fullNewHierarchy = [...newHierarchy, newTaskId];
+
     setSelectedTaskId(newTaskId);
-
-    setActiveColumns(newHierarchy);
-
+    setSelectedTaskHierarchy(fullNewHierarchy);
+    setActiveColumns(fullNewHierarchy);
   };
 
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);


### PR DESCRIPTION
Board.tsxのhandleTaskAdded関数を修正し、
タスク追加後に新しいタスクが選択され、
そのタスクを含む正しい階層でカラムがアクティブになるようにしました。

setSelectedTaskHierarchyとsetActiveColumnsに
新しいタスクIDを含む完全な階層情報を渡すように変更しました。
これにより、リロードなしで追加タスクが画面に表示されることを目指します。