### PR TITLE
Debug: タスク追加時の表示更新に関するログを追加

### DIFF
--- a/react-ts-app/src/components/Board.tsx
+++ b/react-ts-app/src/components/Board.tsx
@@ -33,27 +33,40 @@ const Board: React.FC = () => {
   const [focusedColumnIdForPrint, setFocusedColumnIdForPrint] = useState<string | null>(null);
 
   const handleTaskAdded = (newTaskId: string, taskParentId: string | null) => {
+    console.log('[Board.tsx] handleTaskAdded CALLED with newTaskId:', newTaskId, 'taskParentId:', taskParentId);
     const currentTasks = useTaskStore.getState().tasks;
     const newTask = currentTasks[newTaskId];
-    if (!newTask) return;
+    if (!newTask) {
+      console.error('[Board.tsx] handleTaskAdded - newTask not found in store!', newTaskId);
+      return;
+    }
+    console.log('[Board.tsx] handleTaskAdded - newTask:', JSON.parse(JSON.stringify(newTask)));
 
-    let newHierarchy: string[] = []; // 親までの階層
+    let newHierarchy: string[] = [];
     if (taskParentId) {
       const buildHierarchy = (currentId: string, path: string[]): string[] => {
-        const t = currentTasks[currentId]; // currentTasks を使用
+        const t = currentTasks[currentId];
         if (!t) return path;
         path.unshift(currentId);
         return t.parentId ? buildHierarchy(t.parentId, path) : path;
       };
       newHierarchy = buildHierarchy(taskParentId, []);
     }
+    console.log('[Board.tsx] handleTaskAdded - Parent hierarchy:', JSON.parse(JSON.stringify(newHierarchy)));
 
-    // 新しいタスク自身を含む完全な階層を作成
     const fullNewHierarchy = [...newHierarchy, newTaskId];
+    console.log('[Board.tsx] handleTaskAdded - Full new hierarchy for setActiveColumns/setSelectedTaskHierarchy:', JSON.parse(JSON.stringify(fullNewHierarchy)));
 
     setSelectedTaskId(newTaskId);
     setSelectedTaskHierarchy(fullNewHierarchy);
     setActiveColumns(fullNewHierarchy);
+    console.log('[Board.tsx] handleTaskAdded - Called setSelectedTaskId, setSelectedTaskHierarchy, setActiveColumns');
+
+    // 呼び出し直後のストアの状態を確認 (オプション)
+    // setTimeout(() => {
+    //   const latestColumns = useTaskStore.getState().columns;
+    //   console.log('[Board.tsx] handleTaskAdded - Columns in store AFTER async update (length):', latestColumns.length, JSON.parse(JSON.stringify(latestColumns)));
+    // }, 0);
   };
 
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);

--- a/react-ts-app/src/store/useTaskStore.ts
+++ b/react-ts-app/src/store/useTaskStore.ts
@@ -258,6 +258,7 @@ export const useTaskStore = create<TaskState>()(
       })),
 
       setActiveColumns: (selectedTaskIdsHierarchy: string[]) => {
+        console.log('[useTaskStore] setActiveColumns CALLED with hierarchy:', JSON.parse(JSON.stringify(selectedTaskIdsHierarchy)));
         set((state) => {
           const newColumns: TaskColumn[] = [];
           let level = 0;
@@ -267,18 +268,27 @@ export const useTaskStore = create<TaskState>()(
             parentTaskId: null,
             level: level++,
           });
+          console.log('[useTaskStore] setActiveColumns - Root column created:', JSON.parse(JSON.stringify(newColumns[0])));
           for (const taskId of selectedTaskIdsHierarchy) {
             const task = state.tasks[taskId];
             if (task && task.childrenIds && task.childrenIds.length > 0) {
-              newColumns.push({
+              const childColumn = {
                 id: `column-${taskId}-${Date.now()}`,
                 taskIds: task.childrenIds.filter(id => !!state.tasks[id]),
                 parentTaskId: taskId,
                 level: level++,
-              });
+              };
+              newColumns.push(childColumn);
+              console.log('[useTaskStore] setActiveColumns - Child column for', taskId, 'created:', JSON.parse(JSON.stringify(childColumn)));
             }
           }
-          return { columns: newColumns.slice(0, 5) };
+          const finalColumns = newColumns.slice(0, 5);
+          console.log('[useTaskStore] setActiveColumns - FINAL newColumns to be set (length):', finalColumns.length, JSON.parse(JSON.stringify(finalColumns)));
+          // 以前のcolumnsと比較するためのログ
+          if (state.columns) {
+              console.log('[useTaskStore] setActiveColumns - OLD columns (length):', state.columns.length, JSON.parse(JSON.stringify(state.columns)));
+          }
+          return { columns: finalColumns }; // Ensure a new reference is returned
         });
       },
 


### PR DESCRIPTION
タスク追加後に画面が自動でリフレッシュされない問題の調査のため、
useTaskStore.tsのsetActiveColumns関数と、
Board.tsxのhandleTaskAdded関数に詳細なデバッグログを追加しました。

これにより、状態の変更とコンポーネントへの伝播を追跡し、
問題の原因を特定しやすくします。