### PR TITLE
Fix: タスク追加時の自動表示更新を окончательный (final) に

### DIFF
--- a/react-ts-app/src/components/Board.tsx
+++ b/react-ts-app/src/components/Board.tsx
@@ -33,14 +33,12 @@ const Board: React.FC = () => {
   const [focusedColumnIdForPrint, setFocusedColumnIdForPrint] = useState<string | null>(null);
 
   const handleTaskAdded = (newTaskId: string, taskParentId: string | null) => {
-    console.log('[Board.tsx] handleTaskAdded CALLED with newTaskId:', newTaskId, 'taskParentId:', taskParentId);
     const currentTasks = useTaskStore.getState().tasks;
     const newTask = currentTasks[newTaskId];
     if (!newTask) {
-      console.error('[Board.tsx] handleTaskAdded - newTask not found in store!', newTaskId);
+      // console.error('[Board.tsx] handleTaskAdded - newTask not found in store!', newTaskId); // エラーログは残す選択肢もある
       return;
     }
-    console.log('[Board.tsx] handleTaskAdded - newTask:', JSON.parse(JSON.stringify(newTask)));
 
     let newHierarchy: string[] = [];
     if (taskParentId) {
@@ -52,21 +50,12 @@ const Board: React.FC = () => {
       };
       newHierarchy = buildHierarchy(taskParentId, []);
     }
-    console.log('[Board.tsx] handleTaskAdded - Parent hierarchy:', JSON.parse(JSON.stringify(newHierarchy)));
 
     const fullNewHierarchy = [...newHierarchy, newTaskId];
-    console.log('[Board.tsx] handleTaskAdded - Full new hierarchy for setActiveColumns/setSelectedTaskHierarchy:', JSON.parse(JSON.stringify(fullNewHierarchy)));
 
     setSelectedTaskId(newTaskId);
     setSelectedTaskHierarchy(fullNewHierarchy);
     setActiveColumns(fullNewHierarchy);
-    console.log('[Board.tsx] handleTaskAdded - Called setSelectedTaskId, setSelectedTaskHierarchy, setActiveColumns');
-
-    // 呼び出し直後のストアの状態を確認 (オプション)
-    // setTimeout(() => {
-    //   const latestColumns = useTaskStore.getState().columns;
-    //   console.log('[Board.tsx] handleTaskAdded - Columns in store AFTER async update (length):', latestColumns.length, JSON.parse(JSON.stringify(latestColumns)));
-    // }, 0);
   };
 
   const [isTaskModalOpen, setIsTaskModalOpen] = useState(false);

--- a/react-ts-app/src/store/useTaskStore.ts
+++ b/react-ts-app/src/store/useTaskStore.ts
@@ -258,7 +258,6 @@ export const useTaskStore = create<TaskState>()(
       })),
 
       setActiveColumns: (selectedTaskIdsHierarchy: string[]) => {
-        console.log('[useTaskStore] setActiveColumns CALLED with hierarchy:', JSON.parse(JSON.stringify(selectedTaskIdsHierarchy)));
         set((state) => {
           const newColumns: TaskColumn[] = [];
           let level = 0;
@@ -268,7 +267,6 @@ export const useTaskStore = create<TaskState>()(
             parentTaskId: null,
             level: level++,
           });
-          console.log('[useTaskStore] setActiveColumns - Root column created:', JSON.parse(JSON.stringify(newColumns[0])));
           for (const taskId of selectedTaskIdsHierarchy) {
             const task = state.tasks[taskId];
             if (task && task.childrenIds && task.childrenIds.length > 0) {
@@ -279,15 +277,9 @@ export const useTaskStore = create<TaskState>()(
                 level: level++,
               };
               newColumns.push(childColumn);
-              console.log('[useTaskStore] setActiveColumns - Child column for', taskId, 'created:', JSON.parse(JSON.stringify(childColumn)));
             }
           }
           const finalColumns = newColumns.slice(0, 5);
-          console.log('[useTaskStore] setActiveColumns - FINAL newColumns to be set (length):', finalColumns.length, JSON.parse(JSON.stringify(finalColumns)));
-          // 以前のcolumnsと比較するためのログ
-          if (state.columns) {
-              console.log('[useTaskStore] setActiveColumns - OLD columns (length):', state.columns.length, JSON.parse(JSON.stringify(state.columns)));
-          }
           return { columns: finalColumns }; // Ensure a new reference is returned
         });
       },


### PR DESCRIPTION
タスク追加後に画面リロードなしで新しいタスクが表示されるように修正しました。
以前のブランチ(feat/auto-refresh-after-add, debug/task-refresh-logging)での対応に加え、 Board.tsxのhandleTaskAdded関数内の階層設定ロジックを確実にし、
不要になったデバッグログを削除しました。

主な修正点:
- TaskModalからBoardへのタスク追加通知コールバック(onTaskAdded)を実装。
- BoardのhandleTaskAddedで、新しいタスクの階層を正しく計算し、 setSelectedTaskId, setSelectedTaskHierarchy, setActiveColumns を更新。
- デバッグ用のconsole.logを削除。